### PR TITLE
Prevent Undefined Error When Accessing initialData[2].length

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export async function scraper(url, { sort_type = "relevent", search_query = "", 
         const sort = SortEnum[sort_type];
         const initialData = await fetchReviews(url, sort, "", search_query);
 
-        if (!initialData || !initialData[2].length) return 0;
+        if (!initialData || !initialData[2] || !initialData[2].length) return 0;
 
         if (!initialData[1] || pages === 1) return clean ? parseReviews(initialData[2]) : initialData[2];
 


### PR DESCRIPTION
This pull request addresses an issue where the application throws a Cannot read properties of undefined (reading 'length') error. The error occurs when initialData[2] is undefined or null, and the code attempts to access its length property.