### PR TITLE
[FIX] correct of "relevant" in SortEnum with backward compatibility

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,13 +2,12 @@
 
 <div align="center">
 
-![](https://img.shields.io/github/license/YasogaN/google-maps-review-scraper.svg?style=for-the-badge&color=blue) 
-![](https://img.shields.io/github/forks/YasogaN/google-maps-review-scraper.svg?style=for-the-badge) 
-![](https://img.shields.io/github/stars/YasogaN/google-maps-review-scraper.svg?style=for-the-badge) 
-![](https://img.shields.io/github/watchers/YasogaN/google-maps-review-scraper.svg?style=for-the-badge) 
-![](https://img.shields.io/github/issues/YasogaN/google-maps-review-scraper.svg?style=for-the-badge) 
-![](https://img.shields.io/github/languages/code-size/YasogaN/google-maps-review-scraper?style=for-the-badge) 
-
+![](https://img.shields.io/github/license/YasogaN/google-maps-review-scraper.svg?style=for-the-badge&color=blue)
+![](https://img.shields.io/github/forks/YasogaN/google-maps-review-scraper.svg?style=for-the-badge)
+![](https://img.shields.io/github/stars/YasogaN/google-maps-review-scraper.svg?style=for-the-badge)
+![](https://img.shields.io/github/watchers/YasogaN/google-maps-review-scraper.svg?style=for-the-badge)
+![](https://img.shields.io/github/issues/YasogaN/google-maps-review-scraper.svg?style=for-the-badge)
+![](https://img.shields.io/github/languages/code-size/YasogaN/google-maps-review-scraper?style=for-the-badge)
 
 ## Frameworks/Technologies
 
@@ -25,31 +24,35 @@ Install with npm
 ```bash
   npm install google-maps-review-scraper
 ```
+
 Install with yarn
+
 ```bash
   yarn add google-maps-review-scraper
 ```
+
 ---
 
 ## Usage/Examples
 
 ```ts
-import { scraper } from "google-maps-review-scraper"
+import { scraper } from "google-maps-review-scraper";
 
-const reviews = await scraper("url", { 
-    sort_type: "relevent", 
-    search_query: "search_query", 
-    pages: "pages", 
-    clean: false, 
-    experimental: false, 
-    cookies: { "__Secure-1PSID": "...", "__Secure-1PSIDTS": "..." } 
-})
+const reviews = await scraper("url", {
+  sort_type: "relevant",
+  search_query: "search_query",
+  pages: "pages",
+  clean: false,
+  experimental: false,
+  cookies: { "__Secure-1PSID": "...", "__Secure-1PSIDTS": "..." },
+});
 ```
 
 ### Arguments
-`url` - `string`: A google maps place url as explained [here](https://github.com/YasogaN/google-maps-review-scraper/blob/main/docs/urls/place.md) 
 
-`sort_type` - `string`: The sort parameter (`"relevent"`, `"newest"`, `"highest_rating"`, `"lowest_rating"`). Defaults to `"relevent"`
+`url` - `string`: A google maps place url as explained [here](https://github.com/YasogaN/google-maps-review-scraper/blob/main/docs/urls/place.md)
+
+`sort_type` - `string`: The sort parameter (`"relevant"`, `"newest"`, `"highest_rating"`, `"lowest_rating"`). Defaults to `"relevant"`
 
 `search_query` - `string`: Search query to search in reviews. Defaults to nothing.
 
@@ -80,7 +83,6 @@ All documentation related to API's and URL's used in this project can be found i
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/YasogaN/google-maps-review-scraper/blob/main/LICENSE) file for details.
 
-
 ### Summary of the MIT License
 
 The **MIT License** is a permissive open-source license that allows users significant freedom with minimal conditions.
@@ -97,6 +99,7 @@ The **MIT License** is a permissive open-source license that allows users signif
 - **Attribution**: You must include the original copyright notice and the MIT license text in any copies or substantial portions of the software.
 
 ### No Warranty:
+
 - The software is provided "as is," with no warranties or guarantees. The author is not liable for any damages arising from the use of the software.
 
 For full details, refer to the license text.
@@ -123,8 +126,8 @@ Thanks to Minh for helping keep the library maintained!
 
 ### Dependencies
 
- - [impit](https://github.com/apify/impit) by [@apify](https://github.com/apify)
- - [tough-cookie](https://github.com/salesforce/tough-cookie) by [@salesforce](https://github.com/salesforce)
+- [impit](https://github.com/apify/impit) by [@apify](https://github.com/apify)
+- [tough-cookie](https://github.com/salesforce/tough-cookie) by [@salesforce](https://github.com/salesforce)
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { createClient } from "./client.js";
  *
  * @param {string} url - The URL of the Google Maps location to scrape reviews from.
  * @param {Object} options - The options for scraping.
- * @param {string} [options.sort_type="relevent"] - The type of sorting for the reviews ("relevent", "newest", "highest_rating", "lowest_rating").
+ * @param {string} [options.sort_type="relevant"] - The type of sorting for the reviews ("relevant", "newest", "highest_rating", "lowest_rating").
  * @param {string} [options.search_query=""] - The search query to filter reviews.
  * @param {string} [options.pages="max"] - The number of pages to scrape (default is "max"). If set to a number, it will scrape that number of pages (results will be 10 * pages) or until there are no more reviews.
  * @param {boolean} [options.clean=false] - Whether to return clean reviews or not.
@@ -19,7 +19,7 @@ import { createClient } from "./client.js";
  */
 export async function scraper(
     url: string,
-    { sort_type = "relevent", search_query = "", pages = "max", clean = false, experimental = false, cookies = undefined }: any = {}
+    { sort_type = "relevant", search_query = "", pages = "max", clean = false, experimental = false, cookies = undefined }: any = {}
 ) {
     try {
         validateParams(url, sort_type, pages, clean);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export enum SortEnum {
     "relevent" = 1,
+    "relevant" = 1,
     "newest" = 2,
     "highest_rating" = 3,
     "lowest_rating" = 4

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import parser from "./parser.js";
 /**
  * Validates parameters for the Google Maps review scraper.
  * @param {string} url - The URL of the Google Maps location to scrape reviews from.
- * @param {string} sort_type - The type of sorting for the reviews ("relevent", "newest", "highest_rating", "lowest_rating").
+ * @param {string} sort_type - The type of sorting for the reviews ("relevant", "newest", "highest_rating", "lowest_rating").
  * @param {string | number} pages - The number of pages to scrape (default is "max"). If set to a number, it will scrape that number of pages (results will be 10 * pages) or until there are no more reviews.
  * @param {boolean} clean - Whether to return clean reviews or not.
  */


### PR DESCRIPTION
## Summary
This commit fixes a spelling error in the `SortEnum` where "relevent" was changed to "relevant" while maintaining backward compatibility by keeping both spellings in the enum mapping to the same value.

## Technical Changes
- **ReadMe.md**: 
  - Corrected spelling in usage examples (`sort_type: "relevant"`)
  - Updated documentation for `sort_type` argument to reflect correct spelling
  - Removed extra blank lines in badge section for cleaner formatting
- **src/index.ts**:
  - Updated JSDoc for `sort_type` parameter to show correct spelling
  - Changed default value from `"relevent"` to `"relevant"`
- **src/types.ts**:
  - Added `"relevant" = 1` to SortEnum while preserving `"relevent" = 1` for backward compatibility
- **src/utils.ts**:
  - Corrected spelling in JSDoc for `validateParams` function

## Key Features
- Maintains backward compatibility - both "relevent" and "relevant" now work as sort options
- Fixes documentation to show correct spelling
- Improves code consistency

## Breaking / Migration Impact
- **None** - The change is fully backward compatible. Existing code using "relevent" continues to work unchanged because both enum values map to the same numeric value (1).

## Measurable Impact
- Fixes typo that would have caused confusion for new users
- Ensures documentation matches actual implementation
- No performance or functional changes - purely a correctness fix

The fix addresses inconsistent spelling throughout the codebase while ensuring no existing integrations are broken. Users can now use either spelling interchangeably.