### PR TITLE
Added review response to clean data

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -56,7 +56,7 @@ All arguments are passed as a single object:
 
 `sort_type` - `string`: Sort order (`"relevant"`, `"newest"`, `"highest_rating"`, `"lowest_rating"`). Defaults to `"relevant"`.
 
-`pages` - `number`: Number of pages to scrape (each page yields ~10 reviews). Defaults to all available pages. Set to `-1` for unlimited.
+`pages` - `number`: Number of pages to scrape (each page yields ~10 reviews). Defaults to all available pages. Set to `-1` for unlimited. To capture all reviews, use the `"newest"` sort order and unlimited pages.
 
 `clean` - `boolean`: Whether to return a cleaned/parsed output (`ParsedReview[]`) or raw JSON (`JsonArray`). Defaults to `false`.
 

--- a/src/boqParser.ts
+++ b/src/boqParser.ts
@@ -61,7 +61,7 @@ function _lastIndex<T>(arr: T[], predicate: (v: T | undefined) => boolean): numb
  * @returns A parsed review object, or `null` if the entry is invalid.
  */
 function _parseReview(review: unknown): ParsedReview | null {
-    if (!Array.isArray(review) || review.length < 5) return null;
+    if (!Array.isArray(review) || review.length < 6) return null;
 
     const rating = numberOrZero(review[1]);
 
@@ -75,6 +75,9 @@ function _parseReview(review: unknown): ParsedReview | null {
     let authorId = "Unknown";
     const match = authorUrl.match(/\/contrib\/(\d+)/);
     if (match?.[1]) authorId = match[1];
+
+    const responseArr = review[4];
+    const responseText = stringOrEmpty(Array.isArray(responseArr) ? responseArr[2] : null);
 
     const reviewId = stringOrEmpty(review[5]);
 
@@ -120,7 +123,13 @@ function _parseReview(review: unknown): ParsedReview | null {
         review: { rating, text: fullText ?? shortText, language },
         images,
         source: "Google Local Search Panel",
-        response: null,
+        response: {
+            text: responseText,
+            time: {
+                published: null,
+                last_edited: null,
+            }
+        },
     };
 }
 


### PR DESCRIPTION
I needed to extract all reviews of a [restaurant](https://www.google.com/maps/place/Meta+dos+Leit%C3%B5es/@40.3933238,-8.4503946,551m/data=!3m1!1e3!4m6!3m5!1s0xd2254b398404225:0x13c80875de7b24c1!8m2!3d40.3940782!4d-8.4503927!16s%2Fg%2F1tcvw3wh?entry=ttu&g_ep=EgoyMDI2MDgxOS4wIKXMDSoASAFQAw%3D%3D) on google maps. I installed the tool and figured out the `"newest"` option yielded the most reviews. I compared the number of elements in the output json array (5185) was close to the reported figure on the maps page plus the 3 preview reviews (5181+3) so I assumed it got all of them.

I also needed the owner responses, but I found none in the clean outputs when there should be some. I compared the raw and clean outputs, figured out the array location and filled the appropriate field in the clean data, according to the schema.